### PR TITLE
Refactor file to base 64 method

### DIFF
--- a/src/lib/shufti.js
+++ b/src/lib/shufti.js
@@ -92,17 +92,19 @@ async function postRequest(token, payload, secretKey) {
     console.error(error);
   }
 }
+
 async function fileToBase64(file) {
-  return new Promise((resolve, reject) => {
+  try {
     const reader = new FileReader();
     reader.readAsDataURL(file);
-    reader.onload = () => {
-      const base64 = reader.result.split(',')[1];
-
-      resolve(`data:image/jpeg;base64,${base64}`);
-    };
-    reader.onerror = error => reject(error);
-  });
+    await new Promise(resolve => {
+      reader.onload = () => resolve();
+    });
+    const base64 = reader.result.split(',')[1];
+    return base64;
+  } catch (error) {
+    throw error;
+  }
 }
 
 export {


### PR DESCRIPTION
## Item

The fileToBase64 method in libs should be written on async await syntax




<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Refactor: Refactored the `fileToBase64` method in the `libs` file to use async/await syntax and added error handling. This improves the code's readability and maintainability.
<!-- end of auto-generated comment: release notes by openai -->